### PR TITLE
PM-1726: reverted python version to 3.8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM nikolaik/python-nodejs:python3.9-nodejs14
+FROM nikolaik/python-nodejs:python3.8-nodejs14
 
 
 LABEL version="1.0.0"


### PR DESCRIPTION
(3.9 not supported by AWS)